### PR TITLE
Pass in nil for the options in the Bolt Open call

### DIFF
--- a/db/db.go
+++ b/db/db.go
@@ -15,7 +15,7 @@ type DB struct {
 // Open initializes and opens the database.
 func (db *DB) Open(path string, mode os.FileMode) error {
 	var err error
-	db.DB, err = bolt.Open(path, mode)
+	db.DB, err = bolt.Open(path, mode, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Hey, it wasn't compiling with the latest version of Bolt. Looks like they've added a new `options` param to the `Open` signature. Docs here: http://godoc.org/github.com/boltdb/bolt#Open

I just added in nil for now.
