### PR TITLE
update package path of goji/param

### DIFF
--- a/wiki/update.go
+++ b/wiki/update.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/peterhellberg/wiki/db"
-	"github.com/zenazn/goji/param"
+	"github.com/goji/param"
 	"github.com/zenazn/goji/web"
 )
 


### PR DESCRIPTION
goji/param is now refactored into a new package - https://github.com/goji/param per https://github.com/zenazn/goji/commit/1142ca60ec2658b7fa9c899f18add5b092a45fe2#diff-d41d8cd98f00b204e9800998ecf8427e
